### PR TITLE
Form action changed to "/submit.html". Fixes #26

### DIFF
--- a/code/mysite/myapp/templates/submit.html
+++ b/code/mysite/myapp/templates/submit.html
@@ -3,7 +3,7 @@
 
 <center>
 <p>Submit request: </p>
-<form action="/" method="post" enctype="multipart/form-data">
+<form action="/submit.html" method="post" enctype="multipart/form-data">
     {% csrf_token %}
     <table>
         {{ form.as_table }}


### PR DESCRIPTION
Previous action was set to the root page (index.html). When the submit button was pressed the browser would take the user back to the index page without submitting form data - because of this issues were not saving properly.